### PR TITLE
fixing bug for categories page not showing

### DIFF
--- a/buildlog.txt
+++ b/buildlog.txt
@@ -4,3 +4,4 @@
 1.2.0 - category statistics view
 2.0.0 - register functionality
 2.0.1 - fixed bug where registering users always hit the 'email already exists' catch
+2.0.2 - fixed bug where category page errored out on certain browsers

--- a/src/app/(main)/history/categories/page.js
+++ b/src/app/(main)/history/categories/page.js
@@ -117,7 +117,7 @@ export default function CategoryView() {
     );
   }
 
-  if (historyLoading) {
+  if (historyLoading || !categoryObj) {
     return (
       <Box
         sx={{
@@ -134,7 +134,7 @@ export default function CategoryView() {
     );
   }
 
-  if (!categoryStats) {
+  if (!compareStats || !categoryStats) {
     return (
       <Box
         sx={{


### PR DESCRIPTION
Fixing a bug where the history category page was erroring out on certain browsers